### PR TITLE
remove # from before e.g. "http://www.w3.org/2000/xmlns/"

### DIFF
--- a/environment.lisp
+++ b/environment.lisp
@@ -83,8 +83,8 @@
 
 (defparameter *initial-namespaces*
   '((nil . "")
-    ("xmlns" . #"http://www.w3.org/2000/xmlns/")
-    ("xml" . #"http://www.w3.org/XML/1998/namespace")))
+    ("xmlns" . "http://www.w3.org/2000/xmlns/")
+    ("xml" . "http://www.w3.org/XML/1998/namespace")))
 
 (defvar *dynamic-namespaces* *initial-namespaces*)
 (defvar *dynamic-var-bindings* nil)


### PR DESCRIPTION
 * The # shoudln't be needed and throws off ABCL's
   jss-reader. Arguably the fix is not to use the jss-reader but
   there's no need that I can see for the # here.