### PR TITLE
Xpath test cleanup

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -123,8 +123,21 @@
     @aboutfun{matching-values}
     @end{section}"))
 
+(defpackage :xpath-utils
+  (:use #:cl)
+  (:export #:mklist
+           #:concat
+           #:string-replace
+           #:trim
+           #:with-gensyms
+           #:once-only
+           #:proper-list-p
+           #:maybe-progn
+           #:hypsym
+           #:with-cache))
+
 (defpackage :xpath
-  (:use cl :xpattern)
+  (:use cl :xpattern #:xpath-utils)
   (:import-from :xpath-protocol #:define-default-method)
   (:intern #:make-node-set
            #:make-pipe

--- a/parser-test.lisp
+++ b/parser-test.lisp
@@ -27,7 +27,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(in-package :xpath-test)
 
 (defun test-lexer (str)
   (let* ((l '())

--- a/test.lisp
+++ b/test.lisp
@@ -27,7 +27,38 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(cl:defpackage #:xpath-test
+  (:use #:common-lisp #:xpath #:xpattern #:xpath-utils)
+  (:import-from #:xpath
+                #:make-pipe
+                #:mappend-pipe
+                #:pipe-head
+                #:pipe-tail
+                #:pipe-of
+                #:force
+                #:get-node-text
+                #:xnum-p
+                #:+NAN+
+                #:with-float-traps-masked
+                #:compare-values
+                #:compare-numbers
+                #:make-node-set
+                #:parse-xnum
+                #:assert-float-equal*
+                #:xnum-/
+                #:xnum-*
+                #:xnum-+
+                #:xnum--
+                #:xnum-mod
+                #:xnum-round
+                #:xnum-floor
+                #:xnum-ceiling
+                #:xnum->string
+                #:make-fixup-lexer
+                #:make-test-environment
+                #:xpath-lexer))
+
+(in-package #:xpath-test)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/utils.lisp
+++ b/utils.lisp
@@ -27,7 +27,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(in-package :xpath-utils)
 
 (defun mklist (value)
   (if (atom value) (list value) value))

--- a/xnum-ieee-test.lisp
+++ b/xnum-ieee-test.lisp
@@ -27,7 +27,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(in-package :xpath-test)
 
 ;; TODO: converting to string
 (deftest test-xnum

--- a/xnum-test.lisp
+++ b/xnum-test.lisp
@@ -27,7 +27,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(in-package #:xpath-test)
 
 ;; TODO: converting to string
 (deftest test-xnum

--- a/xpath-test.lisp
+++ b/xpath-test.lisp
@@ -27,7 +27,7 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :xpath)
+(in-package #:xpath-test)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/xpath.asd
+++ b/xpath.asd
@@ -37,10 +37,11 @@
 
 (defsystem "xpath/test"
   :depends-on ("xpath")
-
   :serial t
   :components ((:file "test")
                #+sbcl (:file "xnum-ieee-test")
                #-sbcl (:file "xnum-test")
                (:file "parser-test")
-               (:file "xpath-test")))
+               (:file "xpath-test"))
+  :perform (test-op (o c)
+                    (uiop:symbol-call :xpath-test '#:run-all-tests)))


### PR DESCRIPTION
The xpath tests weren't actually run on asdf:test-op. I've fixed that in this branch.

Also, while I'm at it, I moved the xpath test symbols into their own package, along with the xpath-utils which may deserve to be exported, but probably not as part of the core xpath package. Also, there were a number of non-exported symbols used by the tests and those are now explicitly imported-from in the asdf-test defpackage form.