### PR TITLE
coerce ncname to runes:simple-rod

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -116,7 +116,9 @@
    (:qname (lambda* (a) `(:qname ,(car a) ,(cdr a))))
    :ncname
    (operator-actually-ncname
-    (lambda* (a) (string-downcase (symbol-name a))))
+    (lambda* (a) (coerce
+                  (string-downcase (symbol-name a))
+                  'runes:simple-rod)))
    (:star (lambda* (nil) '*))
    (:node-type-or-function-name
     :lparen :rparen


### PR DESCRIPTION
 * on newish SBCLs (string-downcase (symbol-name ...)) gives back a
   simple-base-string. Coerce this to the new (corrected) definition
   of runes:simple-rod to keep split-qname happy, which expects a simple-rod.